### PR TITLE
removed google plus because it's dead

### DIFF
--- a/layouts/partials/single-partials/share.html
+++ b/layouts/partials/single-partials/share.html
@@ -12,12 +12,6 @@
         <i class="fab fa-facebook-f"></i>
         </a>
         </li>
-        
-        <li class="ml-1 mr-1">
-        <a target="_blank" href="https://plus.google.com/share?url={{ .URL | absLangURL }}" onclick="window.open(this.href, 'google-share', 'width=550,height=435');return false;">
-        <i class="fab fa-google"></i>
-        </a>
-        </li>
 
         <li class="ml-1 mr-1">
         <a target="_blank" href="https://www.xing.com/spi/shares/new?url={{ .URL | absLangURL }}" onclick="window.open(this.href, 'xing-share', 'width=550,height=435');return false;">


### PR DESCRIPTION
I noticed that the Google Plus icon was among the Share icons but sinds the beginning of april Google Plus is dead so I removed it.