### PR TITLE
deprecated .Hugo

### DIFF
--- a/layouts/partials/_shared/head.html
+++ b/layouts/partials/_shared/head.html
@@ -1,7 +1,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        {{ .Hugo.Generator }}
+        {{ hugo.Generator }}
 	{{ with .Site.Params.logo }}
 	<link rel="icon" href="{{ . | urlize | relURL }}">
 	{{ end }}


### PR DESCRIPTION
Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.