### PR TITLE
Twitter links don't have www

### DIFF
--- a/layouts/partials/_shared/social.html
+++ b/layouts/partials/_shared/social.html
@@ -12,7 +12,7 @@
     <a href="https://www.medium.com/@{{.}}"><i class="fab fa-medium social-icon" aria-hidden="true"></i></a>
     {{ end }}
     {{ with .Site.Params.social.twitter }}
-    <a href="https://www.twitter.com/{{.}}"><i class="fab fa-twitter social-icon" aria-hidden="true"></i></a>
+    <a href="https://twitter.com/{{.}}"><i class="fab fa-twitter social-icon" aria-hidden="true"></i></a>
     {{ end }}
     {{ with .Site.Params.social.instagram }}
     <a href="https://www.instagram.com/{{.}}"><i class="fab fa-instagram social-icon" aria-hidden="true"></i></a>


### PR DESCRIPTION
removing this saves a HTTP redirect and saves a few bytes. :-)