### PR TITLE
Add support for cascaded menus

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -45,6 +45,66 @@ Currently trying to get this blog running, still don't know what the blog will b
     identifier = "blog"
     url = "/blog"
 [[menu.main]]
+    name = "Quick Nav"
+    identifier = "quicknav"
+    weight = 150
+    url = "/#"
+[[menu.main]]
+    name = "Ninth"
+    url = "/blog/ninth"
+    parent = "quicknav"
+    weight = 1
+[[menu.main]]
+    name = "Eighth"
+    url = "/blog/eighth"
+    parent = "quicknav"
+    weight = 2
+[[menu.main]]
+    name = "Seventh"
+    url = "/blog/seventh"
+    parent = "quicknav"
+    weight = 3
+[[menu.main]]
+    name = "4-6"
+    url = "#"
+    parent = "quicknav"
+    weight = 4
+[[menu.main]]
+    name = "Sixth"
+    url = "/blog/sixth"
+    parent = "4-6"
+    weight = 1
+[[menu.main]]
+    name = "Fivth"
+    url = "/blog/fivth"
+    parent = "4-6"
+    weight = 2
+[[menu.main]]
+    name = "Fourth"
+    url = "/blog/fourth"
+    parent = "4-6"
+    weight = 3
+[[menu.main]]
+    name = "1-3"
+    url = "#"
+    parent = "quicknav"
+    weight = 5
+[[menu.main]]
+    name = "Third"
+    url = "/blog/third"
+    parent = "1-3"
+    weight = 1
+[[menu.main]]
+    name = "Second"
+    url = "/blog/second"
+    parent = "1-3"
+    weight = 2
+[[menu.main]]
+    name = "First"
+    url = "/blog/my-first-post"
+    parent = "1-3"
+    weight = 3
+[[menu.main]]
     name = "About Me"
     identifier = "about"
     weight = 200

--- a/layouts/partials/_shared/menu-cascaded.html
+++ b/layouts/partials/_shared/menu-cascaded.html
@@ -1,0 +1,22 @@
+<!-- menu-cascaded.html -->
+{{ $menuName := .menu }}
+{{ $currentPage := .current }}
+{{ $currentLevel := .level }}
+<ul class="{{ if eq $currentLevel 1 }}navbar-nav ml-auto {{ else }} navbar-menu-level-{{ $currentLevel }} {{ end }} ">
+    {{ range .pages }} 
+    <li class="nav-item {{ if $currentPage.HasMenuCurrent $menuName . }}active{{ end }}">
+        <a class="nav-link" href="{{ .URL }}">{{ .Name | title }}
+    {{ if .HasChildren }}
+        <span class="drop-icon">&#9662;</span>
+    {{ end }}
+        </a>                
+    {{ if .HasChildren }}
+        {{ partial "_shared/menu-cascaded.html" (dict "menu" $menuName "current" $currentPage "level" (add $currentLevel 1) "pages" .Children) }}
+    {{ end }}
+    </li>
+    {{ end }}
+</ul>
+
+
+
+

--- a/layouts/partials/_shared/navbar.html
+++ b/layouts/partials/_shared/navbar.html
@@ -20,14 +20,7 @@
 
         <!-- Begin Menu -->
         <div class="collapse navbar-collapse" id="navbarMediumish">
-            {{ $currentPage := . }}
-            <ul class="navbar-nav ml-auto">
-                {{ range .Site.Menus.main }} 
-                <li class="nav-item {{ if $currentPage.HasMenuCurrent "main" . }}active{{ end }}">
-                    <a class="nav-link" href="{{ .URL }}">{{ .Name | title }}</a>
-                </li>
-                {{ end }}
-            </ul>
+            {{ partial "_shared/menu-cascaded.html" (dict "menu" "main" "current" . "level" 1 "pages" .Site.Menus.main) }}
         </div>
         <!-- End Menu -->
     </div>

--- a/static/css/medium.css
+++ b/static/css/medium.css
@@ -100,6 +100,38 @@ section.recent-posts {
     }
 }
 
+.drop-icon {
+  font-size: 18px;
+}
+
+.navbar-menu-level-2, .navbar-menu-level-3, .navbar-menu-level-4, .navbar-menu-level-5 {
+    list-style: none;
+    position: absolute;
+    display: none;
+    margin: 0;
+    padding-left: 10px;
+    opacity: 1;
+    line-height: 0.5em;
+    background-color: white;
+}
+
+.navbar-nav {
+    line-height: 0.4em;
+}
+
+.navbar-nav > .nav-item:hover > .navbar-menu-level-2 {
+    display: block;
+}
+.navbar-menu-level-2 > .nav-item:hover > .navbar-menu-level-3 {
+    display: block;
+}
+.navbar-menu-level-3:hover > .nav-item:hover >.navbar-menu-level-4 {
+    display: block;
+}
+.navbar-menu-level-4:hover > .nav-item:hover >.navbar-menu-level-5 {
+    display: block;
+}
+
 .listfeaturedtag {
     border: 1px solid rgba(0, 0, 0, .125);
     border-radius: .25rem;


### PR DESCRIPTION
Hugo supports cascaded menus by defining a "parent" property. This is not supported by the Mediumish theme currently. This pull request adds this functionaility.

The code is not bullet-proof, e.g. I did not test it on mobile devices and only with a single browser (Firefox). It may be useful for many users to have this feature supported.
My use case is a quick navigation if you have many blog entries. I added an example to the example site. The code could be simplified a bit if you rename css class "navbar-nav" to "navbar-menu-level-1". I tried this but it breaks the menu. I guess this class is partially defined outside of file medium.css

Inspired by [this](https://codingnconcepts.com/hugo/nested-menu-hugo/) and [this](https://discourse.gohugo.io/t/go-template-programming-partials-pipe-use-as-functions-recursive/11444)

Example:
<img width="870" alt="CascadedMenu" src="https://user-images.githubusercontent.com/7109466/93722186-44ba9980-fb95-11ea-9034-e2757d7d00b1.png">